### PR TITLE
Allow setting a custom .env path

### DIFF
--- a/src/Bootloader/DotenvBootloader.php
+++ b/src/Bootloader/DotenvBootloader.php
@@ -22,11 +22,16 @@ final class DotenvBootloader extends Bootloader
      */
     public function boot(DirectoriesInterface $dirs, EnvironmentInterface $env)
     {
-        if (!file_exists($dirs->get('root') . '.env')) {
+        $dotenvPath = $env->get('DOTENV_PATH', $dirs->get('root') . '.env');
+
+        if (!file_exists($dotenvPath)) {
             return;
         }
 
-        foreach (Dotenv::create($dirs->get('root'))->load() as $key => $value) {
+        $path = dirname($dotenvPath);
+        $file = basename($dotenvPath);
+
+        foreach (Dotenv::create($path, $file)->load() as $key => $value) {
             $env->set($key, $value);
         }
     }

--- a/tests/.env.custom
+++ b/tests/.env.custom
@@ -1,0 +1,1 @@
+KEY=custom_value

--- a/tests/DotEnv/LoadTest.php
+++ b/tests/DotEnv/LoadTest.php
@@ -41,4 +41,20 @@ class LoadTest extends TestCase
 
         $this->assertSame('value', $e->get('KEY'));
     }
+
+    public function testFoundCustom()
+    {
+        $e = new Environment([
+            'DOTENV_PATH' => __DIR__ . '/../.env.custom'
+        ]);
+
+        $d = new Directories([
+            'root' => __DIR__ . '/../'
+        ]);
+
+        $b = new DotenvBootloader();
+        $b->boot($d, $e);
+
+        $this->assertSame('custom_value', $e->get('KEY'));
+    }
 }


### PR DESCRIPTION
This diff adds an ability to pass a custom `.env` path in `DOTENV_PATH`.